### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "mime": "^2.5.2",
     "serve-static": "^1.14.1",
     "sockette": "^2.0.6",
-    "ws": "^7.1.2",
-    "yargs": "^14.0.0"
+    "ws": "^7.1.2"
   },
   "devDependencies": {
     "@depository/store": "^0.12.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during the test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
